### PR TITLE
[feat] ResultItem 구현 중

### DIFF
--- a/src/components/search/ResultBoard.js
+++ b/src/components/search/ResultBoard.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import ResultList from "./ResultList";
 
 const Container = styled.div`
     width: 853px;
@@ -17,7 +18,7 @@ const Top = styled.div`
     }
 `
 const Select = styled.select`
-    width: 85px;
+    width: 100px;
     height: 39px;
     border-radius: 10px;
     p {
@@ -54,6 +55,7 @@ const ResultBoard = () => {
                 <h2>32건의 검색결과</h2>
                 <SelectBox classname="select" options={OPTIONS} defaultValue="등록순"></SelectBox>
             </Top>
+            <ResultList/>
         </Container>
     );
 };

--- a/src/components/search/ResultItem.js
+++ b/src/components/search/ResultItem.js
@@ -1,26 +1,57 @@
 import { styled } from "styled-components";
-import { AiOutlineHeart } from "react-icons/ai";
+import { AiFillHeart, AiOutlineHeart } from "react-icons/ai";
+import { useState } from "react";
 
 const ImageBox = styled.div`
     width: 265px;
     height: 322px;
     border-radius: 20px;
     background: #E5E1E1;
+
+    .emptyheart {
+        width: 35px;
+        height: 30px;
+        color: gray;
+        cursor: pointer;
+        transition: transform 300ms ease;
+    }
+
+    .emptyheart:hover {
+        transform: scale(1.1);
+    }
+
+    .fillheart {
+        width: 35px;
+        height: 30px;
+        color: red;
+        cursor: pointer;
+    }
 `
+
 const ImageInnerBox = styled.div`
     width: 221px;
     height: 244px;
 `
 
 function RecommandItem(props) {
+    const [like, setLike] = useState(false);
+
+    const toggleLike = () => {
+        setLike(!like);
+    }
+
     return (
         <>
             <ImageBox>
                 <ImageInnerBox>{props.img}</ImageInnerBox>
+                {like ? (
+                    <AiFillHeart className="fillheart" onClick={toggleLike} />
+                ) : (
+                    <AiOutlineHeart className="emptyheart" onClick={toggleLike} />
+                )}
             </ImageBox>
         </>
     );
-    
 }
 
 export default RecommandItem;

--- a/src/components/search/ResultItem.js
+++ b/src/components/search/ResultItem.js
@@ -1,0 +1,26 @@
+import { styled } from "styled-components";
+import { AiOutlineHeart } from "react-icons/ai";
+
+const ImageBox = styled.div`
+    width: 265px;
+    height: 322px;
+    border-radius: 20px;
+    background: #E5E1E1;
+`
+const ImageInnerBox = styled.div`
+    width: 221px;
+    height: 244px;
+`
+
+function RecommandItem(props) {
+    return (
+        <>
+            <ImageBox>
+                <ImageInnerBox>{props.img}</ImageInnerBox>
+            </ImageBox>
+        </>
+    );
+    
+}
+
+export default RecommandItem;

--- a/src/components/search/ResultList.js
+++ b/src/components/search/ResultList.js
@@ -1,0 +1,17 @@
+import ResultItem from "./ResultItem";
+import { styled } from "styled-components";
+import { ReactComponent as Tire1 } from "assets/images/recommand/tires/kh_hp71.svg";
+
+const Container = styled.div`
+    width: 853px;
+`
+
+const ResultList = () => {
+    return (
+        <Container>
+            <ResultItem img={<Tire1/>}/>
+        </Container>
+    );
+}
+
+export default ResultList;


### PR DESCRIPTION
ResultItem 구현 중인데, 필터 검색 결과 나오는 거 + 페이지 넘어가는 거 구현하려면 백엔드 연동 같이 해야할 것 같아서 일단 UI 위주로 하고 있습니당! 
+ 여러 페이지에서 topbar, header, footer 여러 번 선언 안 하는 방식으로 pages랑 App.js 수정했습니당